### PR TITLE
water observed flag definition

### DIFF
--- a/config/wofs_albers.yaml
+++ b/config/wofs_albers.yaml
@@ -34,7 +34,7 @@ product_definition:
         flags_definition:
             dry:
               bits: [7, 6, 5, 4, 3, 1, 0]  # Ignore sea mask
-              description: No water detected
+              description: Clear and dry
               values: {0: true}
             nodata:
               bits: 0
@@ -50,7 +50,7 @@ product_definition:
               values: {0: false, 1: true}
             terrain_or_low_angle:
               bits: 3
-              description: terrain shadow or low solar angle
+              description: Terrain shadow or low solar angle
               values: {0: false, 1: true}
             high_slope:
               bits: 4
@@ -63,6 +63,10 @@ product_definition:
             cloud:
               bits: 6
               description: Cloudy
+              values: {0: false, 1: true}
+            water_observed:
+              bits: 7
+              description: Classified as water by the decision tree
               values: {0: false, 1: true}
             wet:
               bits: [7, 6, 5, 4, 3, 1, 0]  # Ignore sea mask


### PR DESCRIPTION
The water detection bit did not have a name. This makes it harder to pick and choose which bits we want when using WOfS as a mask.