### PR TITLE
Add email monitoring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,6 @@ from the production of the statistical summary mosaics, and is intended to
 improve consistency with other datacube applications (e.g., parallelisation
 of the workflow employs *distributed* rather than *luigi*).
 
-
 Codebase outline
 ----------------
 
@@ -36,7 +35,6 @@ These consist of an 8-bit integer raster band.
 
 - **Decision tree:** The standard classifier is *band maths* performed on 6 EO source bands (TM 1-5, 7). A published tree with 21 nodes, producing boolean output, comprising of thresholds applied to three raw bands (TM 1, 3, 7) and three band-pair ratio-indices (NDI 52, 43, 72).
 - **Filter masks:** various flags are accumulated onto the output band. Inputs are the landsat image, the pixel quality product, and the elevation model. (The difficulty is generating some of the flags, e.g. terrain shadow.)
-
 
 Summary
 -------
@@ -64,7 +62,6 @@ Results (below) indicate that memory is already within the 2GB/core available, t
 - Most of the time is spent on terrain, but only 5-10% speedup plausible by better implementation.
 - Most limiting factor is rotating the DSM (to approximately align with sunlight) but nontrivial to improve or mitigate this. (May or may not be amenable to cheaper interpolation methods or an algorithm that traverses the array differently.)
 
-
 Overlaps
 --------
 The Landsats collect a swath of data as they pass over the continent. 
@@ -85,7 +82,6 @@ observations. Potential alternate measures would include:
 The usefulness of preserving observation-duplicates (e.g. for investigation of 
 sensitivity to uncontrolled upstream processing parameters) is narrow.
 
-
 Classifier
 ----------
 
@@ -95,12 +91,10 @@ Ideally the PQ product might be a band in the EO product (and include terrain re
 
 Alternative algorithms are under development elsewhere.
 
-
 Terrain
 -------
 
 Terrain algorithms usually begin with finding the gradient component along each of the two axes, typically by operating with a 3x3 kernel. One example is the Rook's case (simply using nearest neighbours on either side of the pixel, which turns out to be a 2nd order finite difference method). Another is the Sobel operator, which additionally applies smoothing along the orthogonal axis. Tang and Pilesjo 2011 showed these belong to a variety of methods which produce statistically similar results (different from a more naive and unbalanced method of differencing the central cell with one neighbour along each axis). Jones 1998 found the Rook's case to give the best accuracy (narrowly followed by Sobel), but the methodology (e.g. noise-free synthetic) may have been biased (to favour balanced methods with more compact footprints). Zhou and Liu 2004 added noise to a synthetic, confirming the Rook's case to be optimal in absence of noise but the Sobel operator was more robust to the noise. 
-
 
 Clouds
 ------
@@ -124,13 +118,11 @@ after logging into the NCI by running:
 Versioning
 ----------
 
-The module version number is set in `wofs/__init__.py`. This version number is based on the **algorithm version number**, which at the moment stands at 1.3. See the `CMI Record for the WOfS Algorithm <http://cmi.ga.gov.au/node/166>`_.
+The module version number is set in `wofs/__init__.py`. This version number is based on the **algorithm version number**, which at the moment stands at 1.4. See the `CMI Record for the WOfS Algorithm <http://cmi.ga.gov.au/node/166>`_.
 
 For minor code changes not affecting the algorithm, increment the least significant digit of the version number.
 
 When committing a version number update, please also git tag with the same version number.
-
-
 
 Packaging
 ---------

--- a/wofs/__init__.py
+++ b/wofs/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-__version__ = "1.3"
+__version__ = "1.4"

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -613,6 +613,8 @@ def submit(index: Index,
                 '--task-desc', str(task_path),
                 '--tag', tag,
                 '--log-queries',
+                '--email-id', email_id,
+                '--email-options', email_options,
                 dry_run_option,
             ],
             qsub_params=dict(

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -502,8 +502,7 @@ def list_configs():
 
 
 @cli.command(name='ensure-products',
-             help="Ensure the products exist for the given WOfS config, create them if necessary."
-)
+             help="Ensure the products exist for the given WOfS config, create them if necessary.")
 @task_app.app_config_option
 @click.option('--dry-run', is_flag=True, default=False,
               help='Check product definition without modifying the database')
@@ -618,7 +617,7 @@ def submit(index: Index,
             ],
             qsub_params=dict(
                 name='wofs-generate-{}'.format(tag),
-                mem='31G',
+                mem='medium',
                 wd=True,
                 nodes=1,
                 walltime='1h'))

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -463,7 +463,7 @@ tag_option = click.option('--tag', type=str,
                           help='Unique id for the job')
 
 # pylint: disable=invalid-name
-pbs_email_options = click.option('--email-options', '-m', default='ae',
+pbs_email_options = click.option('--email-options', '-m', default='abe',
                                  type=click.Choice(['a', 'b', 'e', 'n', 'ae', 'ab', 'be', 'abe']),
                                  help='Send Email when execution is, \n'
                                  '[a = aborted | b = begins | e = ends | n = do not send email]')


### PR DESCRIPTION
**Reason for this pull request**
Qsub job status monitoring via email is missing in the existing `wofs_app` code. Adding `pbs` job monitoring via email would help in monitoring the PBS jobs in an efficient way.

**Proposed solutions**
Update the `wofs_app.py` to notify via email whenever a pbs job is `successfully executed` or `failed to execute` or `aborted`.

- [x] Tests passed (no update to tests required, as the test scenarios were already written as part of `dea-env` testing)