### PR TITLE
Use a nodata value instead of a nodata bit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ config_files = ['config/' + name for name in os.listdir('config')]
 tests_require = ['pytest', 'pytest-cov', 'mock', 'pycodestyle', 'pylint',
                  'hypothesis', 'compliance-checker', 'yamllint']
 extras_require = {
-    'doc': ['Sphinx', 'nbsphinx', 'setuptools', 'sphinx_rtd_theme', 'IPython', 'jupyter_sphinx',
-            'recommonmark'],
+    'terrain': ['scipy', 'ephem'],
     'test': tests_require,
 }
 

--- a/tests/test_bitmask_values.py
+++ b/tests/test_bitmask_values.py
@@ -1,0 +1,40 @@
+import pytest
+from affine import Affine
+
+from datacube.utils.geometry import GeoBox, CRS
+from wofs.virtualproduct import WOfSClassifier
+import xarray as xr
+import numpy as np
+
+
+def test_nodata_bit_setting(sample_data):
+    """
+
+    If no-data bit (bit 1) is set, all other bits should be 0. -- Recommendation from Norman Mueller.
+    """
+
+    classifier = WOfSClassifier()
+
+    wofl = classifier.compute(sample_data).water.data.reshape(-1)
+
+    values_with_nodata_bit_set = wofl[np.bitwise_and(wofl, 1) == 1]
+    assert values_with_nodata_bit_set == 1
+
+
+@pytest.fixture
+def sample_data():
+    required_bands = ['nbart_blue', 'nbart_green', 'nbart_red', 'nbart_nir', 'nbart_swir_1', 'nbart_swir_2', 'fmask']
+
+    return xr.Dataset(
+        {
+            name: (['time', 'y', 'x'],
+                   np.arange(0, 2 ** 16, dtype='uint16').reshape((1, 256, 256)),
+                   {'nodata': 0})
+            for name in required_bands
+        }, attrs={
+            'geobox': GeoBox(256, 256, Affine(0.01, 0.0, 139.95,
+                                              0.0, -0.01, -49.05), CRS('EPSG:3577')),
+            'crs': CRS('EPSG:3577')
+        }, coords={
+            'time': np.array(['2000-01-01'], dtype='datetime64')
+        })

--- a/wofs/__init__.py
+++ b/wofs/__init__.py
@@ -1,3 +1,1 @@
-from __future__ import absolute_import
-
 __version__ = "1.4.1"

--- a/wofs/boilerplate.py
+++ b/wofs/boilerplate.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import xarray
 
 

--- a/wofs/classifier.py
+++ b/wofs/classifier.py
@@ -1,5 +1,4 @@
 # Josh Sixsmith, refactored by BL.
-from __future__ import absolute_import, division
 import numpy
 import logging
 import gc

--- a/wofs/filters.py
+++ b/wofs/filters.py
@@ -1,7 +1,6 @@
 """
 Set individual bitflags needed for wofls.
 """
-from __future__ import absolute_import
 import numpy as np
 import scipy.ndimage
 from wofs import terrain, constants, boilerplate

--- a/wofs/terrain.py
+++ b/wofs/terrain.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division
 import numpy
 import ephem
 from scipy import ndimage

--- a/wofs/use_vp_wofs.py
+++ b/wofs/use_vp_wofs.py
@@ -1,4 +1,3 @@
-
 from datacube.virtual import Transformation, Measurement, construct, DEFAULT_RESOLVER
 import datacube
 

--- a/wofs/virtualproduct.py
+++ b/wofs/virtualproduct.py
@@ -17,6 +17,7 @@ WOFS_OUTPUT = [{
 }, ]
 _LOG = logging.getLogger(__file__)
 
+
 class WOfSClassifier(Transformation):
     """ Applies the wofs algorithm to surface reflectance data.
     Requires bands named
@@ -31,7 +32,7 @@ class WOfSClassifier(Transformation):
         self.c2 = c2
         self.output_measurements = {m['name']: Measurement(**m) for m in WOFS_OUTPUT}
         if dsm_path is None:
-            _LOG.warning('WARNING: DSM not set, terrain shadow will not be calculated')
+            _LOG.warning('WARNING: Path or URL to a DSM is not set. Terrain shadow mask will not be calculated.')
 
     def measurements(self, input_measurements) -> Dict[str, Measurement]:
         return self.output_measurements
@@ -66,10 +67,11 @@ class WOfSClassifier(Transformation):
         wofs = []
         for time in time_selectors:
             if self.dsm_path is None:
-                wofs.append(woffles_ard_no_terrain_filter(data.sel(time=time),
-                            masking_filter=masking_used).to_dataset(name='water'))
+                wofs.append(woffles_ard_no_terrain_filter(data.sel(time=time), masking_filter=masking_used
+                                                          ).to_dataset(name='water'))
             else:
-                wofs.append(woffles_ard(data.sel(time=time), dsm, masking_filter=masking_used).to_dataset(name='water'))
+                wofs.append(woffles_ard(data.sel(time=time), dsm, masking_filter=masking_used
+                                        ).to_dataset(name='water'))
         wofs = xr.concat(wofs, dim='time')
         wofs.attrs['crs'] = data.attrs['crs']
         return wofs

--- a/wofs/vp_wofs.py
+++ b/wofs/vp_wofs.py
@@ -59,8 +59,8 @@ def woffles_ard_no_terrain_filter(ard, masking_filter=fmask_filter):
 
 
 def woffles_ard(ard, dsm, masking_filter=fmask_filter):
-    water = classify_ard(ard) | eo_filter(ard) | masking_filter(ard.fmask) | terrain_filter(dsm, ard.rename(
-        {'nbart_blue': 'blue'}))
+    water = classify_ard(ard) | eo_filter(ard) | masking_filter(ard.fmask) \
+            | terrain_filter(dsm, ard.rename({'nbart_blue': 'blue'}))
 
     assert water.dtype == np.uint8
 

--- a/wofs/vp_wofs.py
+++ b/wofs/vp_wofs.py
@@ -53,6 +53,8 @@ def woffles_ard_no_terrain_filter(ard, masking_filter=fmask_filter):
 
     water = classify_ard(ard) | eo_filter(ard) | masking_filter(ard.fmask)
 
+    _fix_nodata_to_single_value(water)
+
     assert water.dtype == np.uint8
 
     return water
@@ -62,6 +64,14 @@ def woffles_ard(ard, dsm, masking_filter=fmask_filter):
     water = classify_ard(ard) | eo_filter(ard) | masking_filter(ard.fmask) \
             | terrain_filter(dsm, ard.rename({'nbart_blue': 'blue'}))
 
+    _fix_nodata_to_single_value(water)
+
     assert water.dtype == np.uint8
 
     return water
+
+
+def _fix_nodata_to_single_value(dataarray):
+    # Force any values with the NODATA bit set, to be the nodata value
+    nodata_set = np.bitwise_and(dataarray.data, NO_DATA) == NO_DATA
+    dataarray.data[nodata_set] = NO_DATA

--- a/wofs/wofls.py
+++ b/wofs/wofls.py
@@ -19,6 +19,7 @@ Issues:
 """
 import numpy as np
 from wofs import classifier, filters
+from wofs.vp_wofs import _fix_nodata_to_single_value
 
 
 def woffles(nbar, pq, dsm):
@@ -28,6 +29,8 @@ def woffles(nbar, pq, dsm):
         | filters.eo_filter(nbar) \
         | filters.pq_filter(pq.pqa) \
         | filters.terrain_filter(dsm, nbar)
+
+    _fix_nodata_to_single_value(water)
 
     assert water.dtype == np.uint8
 

--- a/wofs/wofls.py
+++ b/wofs/wofls.py
@@ -17,8 +17,6 @@ Issues:
       Also, should quantify whether earth's curvature is significant on tile scale.
     - Yet to profile memory, CPU or IO usage.
 """
-from __future__ import absolute_import
-
 import numpy as np
 from wofs import classifier, filters
 

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -9,7 +9,6 @@ The three entry points are:
 2. datacube-wofs generate
 3. datacube-wofs run
 """
-from __future__ import absolute_import, division
 import logging
 import os
 import copy


### PR DESCRIPTION
Having multiple possible values meaning `nodata` makes it harder to use the output data
when combining overlapped outputs. This PR sets a `nodata` value any time a `nodata` bit
was previously set.

This code is getting messy. There are multiple implementations of the same thing with slight differences. Along with some non-obvious assumptions of the form of input data, whether bands are named `blue` or `nbart_blue`. Also, how `nodata` attributes are being used is somewhat tricky, I think we're doing the same thing twice, but I'm not sure.

I hope this doesn't make things too much worse.