### PR TITLE
wrong-dtype

### DIFF
--- a/tests/test_bitmask_values.py
+++ b/tests/test_bitmask_values.py
@@ -1,34 +1,39 @@
+import dask.array as da
+import numpy as np
 import pytest
+import xarray as xr
 from affine import Affine
 
 from datacube.utils.geometry import GeoBox, CRS
 from wofs.virtualproduct import WOfSClassifier
-import xarray as xr
-import numpy as np
 
 
-def test_nodata_bit_setting(sample_data):
+@pytest.mark.parametrize("c2_data", [False, True])
+def test_nodata_bit_setting(sample_data, c2_data):
     """
 
     If no-data bit (bit 1) is set, all other bits should be 0. -- Recommendation from Norman Mueller.
     """
 
-    classifier = WOfSClassifier()
+    classifier = WOfSClassifier(c2=c2_data)
 
-    wofl = classifier.compute(sample_data).water.data.reshape(-1)
+    wofl = classifier.compute(sample_data)
+    wofl = wofl.compute()
+    wofl = wofl.water.data.reshape(-1)
 
     values_with_nodata_bit_set = wofl[np.bitwise_and(wofl, 1) == 1]
-    assert values_with_nodata_bit_set == 1
+    assert (values_with_nodata_bit_set == 1).all()
+    assert wofl.dtype == np.dtype('uint8')
 
 
-@pytest.fixture
-def sample_data():
+@pytest.fixture(params=[np, da], ids=["numpy", "dask.array"])
+def sample_data(request):
     required_bands = ['nbart_blue', 'nbart_green', 'nbart_red', 'nbart_nir', 'nbart_swir_1', 'nbart_swir_2', 'fmask']
 
-    return xr.Dataset(
+    test_data = xr.Dataset(
         {
             name: (['time', 'y', 'x'],
-                   np.arange(0, 2 ** 16, dtype='uint16').reshape((1, 256, 256)),
+                   request.param.arange(0, 2 ** 16, dtype='uint16').reshape((1, 256, 256)),
                    {'nodata': 0})
             for name in required_bands
         }, attrs={
@@ -38,3 +43,18 @@ def sample_data():
         }, coords={
             'time': np.array(['2000-01-01'], dtype='datetime64')
         })
+    test_data.fmask.attrs['flags_definition'] = {
+        'nodata': {'bits': 0, 'values': {0: False, 1: True}},
+        'valid_aerosol': {'bits': 1, 'values': {0: 'not_valid', 1: 'valid'}},
+        'water': {'bits': 2, 'values': {0: 'not_water', 1: 'water'}},
+        'cloud_or_cirrus': {'bits': 3, 'values': {0: 'not_cloud_or_cirrus',
+                                                  1: 'cloud_or_cirrus'}},
+        'cloud_shadow': {'bits': 4,
+                         'values': {0: 'not_cloud_shadow', 1: 'cloud_shadow'}},
+        'interpolated_aerosol': {'bits': 5,
+                                 'values': {0: 'not_aerosol_interpolated',
+                                            1: 'aerosol_interpolated'}},
+        'aerosol_level': {'bits': [6, 7],
+                          'values': {0: 'climatology', 1: 'low', 2: 'medium',
+                                     3: 'high'}}}
+    return test_data

--- a/tests/test_bitmask_values.py
+++ b/tests/test_bitmask_values.py
@@ -8,7 +8,7 @@ from datacube.utils.geometry import GeoBox, CRS
 from wofs.virtualproduct import WOfSClassifier
 
 
-@pytest.mark.parametrize("c2_data", [False, True])
+@pytest.mark.parametrize("c2_data", [False, True], ids=["ga_landsat", "usgs_col2"])
 def test_nodata_bit_setting(sample_data, c2_data):
     """
 
@@ -22,8 +22,8 @@ def test_nodata_bit_setting(sample_data, c2_data):
     wofl = wofl.water.data.reshape(-1)
 
     values_with_nodata_bit_set = wofl[np.bitwise_and(wofl, 1) == 1]
-    assert (values_with_nodata_bit_set == 1).all()
     assert wofl.dtype == np.dtype('uint8')
+    assert (values_with_nodata_bit_set == 1).all()
 
 
 @pytest.fixture(params=[np, da], ids=["numpy", "dask.array"])

--- a/wofs/vp_wofs.py
+++ b/wofs/vp_wofs.py
@@ -74,4 +74,8 @@ def woffles_ard(ard, dsm, masking_filter=fmask_filter):
 def _fix_nodata_to_single_value(dataarray):
     # Force any values with the NODATA bit set, to be the nodata value
     nodata_set = np.bitwise_and(dataarray.data, NO_DATA) == NO_DATA
-    dataarray.data[nodata_set] = NO_DATA
+
+    # If we don't specifically set the dtype in the following line,
+    # dask arrays explode to int64s. Make sure it stays a uint8!
+    dataarray.data[nodata_set] = np.array(NO_DATA, dtype='uint8')
+


### PR DESCRIPTION
The previous 'fix' to force create nodata values instead of nodata bits had a /very/ 
unintended side effect of causing `int64` output arrays instead of `uint8` when
processing using dask.

This PR adds extra tests for wofs calculation using both numpy and dask arrays,
and both GA style ARD data, and USGS Collection 2 style data (needs scaling).