### PR TITLE
Simplify by removing task_app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ scratch/*
 
 .pytest_cache/
 .vscode
+
+wofs/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+# pyproject.toml
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
+[tool.setuptools_scm]
+write_to = "wofs/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python3
-
 import os
 
 from setuptools import find_packages, setup
 
-here = os.path.abspath(os.path.dirname(__file__))
 config_files = ['config/' + name for name in os.listdir('config')]
 tests_require = ['pytest', 'pytest-cov', 'mock', 'pycodestyle', 'pylint',
                  'hypothesis', 'compliance-checker', 'yamllint']
@@ -24,8 +21,6 @@ setup(
     maintainer_email='',
     packages=find_packages(),
     data_files=[('wofs/config', config_files)],
-    setup_requires=['setuptools_scm'],
-    use_scm_version=True,
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
We're moving all the orchestration and management of regular running to be an external concern managed by Airflow.

That means that a whole bunch of code here can be removed as it just gets in the way of development and testing.