### PR TITLE
Fix terrain issue due to ODC geometry changes

### DIFF
--- a/runtests-docker.sh
+++ b/runtests-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-docker pull opendatacube/datacube-core
+docker pull opendatacube/datacube-tests:latest
 
 # Null out the entrypoint since we aren't (yet) connecting to a database
-docker run --entrypoint "" --rm -v $PWD:/tmp/wofs -w /tmp/wofs \
-opendatacube/datacube-core:latest /bin/sh -c "pip install dist/*.whl && ./check-code.sh"
+docker run --rm -v "$PWD":/tmp/wofs -w /tmp/wofs \
+opendatacube/datacube-tests:latest /bin/sh -c "pip3 install dist/*.whl && ./check-code.sh"

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -1,0 +1,38 @@
+"""
+Test some of the terrain masking functions
+"""
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from datacube.utils.geometry import CRS
+from wofs.terrain import vector_to_crs
+
+# Use slightly less than the projected boundary from
+# https://spatialreference.org/ref/epsg/gda94-australian-albers/
+points_3577 = st.tuples(st.integers(min_value=-5000000, max_value=-3000000),
+                        st.integers(min_value=-1500000, max_value=2500000))
+
+vectors = st.tuples(st.integers(min_value=-100, max_value=100),
+                    st.integers(min_value=-100, max_value=100))
+
+
+@given(points_3577, vectors)
+def test_vector_to_crs(orig_point, orig_vect):
+    """
+    Given a random point (in EPSG:3577) and vector, convert to EPSG:4326
+    and back
+
+    Ensure you get your starting values back (approximately)
+    """
+    inter_point, inter_vect = vector_to_crs(orig_point, orig_vect,
+                                            original_crs=CRS('EPSG:3577'),
+                                            destination_crs=CRS('EPSG:4326'))
+
+    new_point, new_vect = vector_to_crs(inter_point, inter_vect,
+                                        original_crs=CRS('EPSG:4326'),
+                                        destination_crs=CRS('EPSG:3577'))
+
+    assert orig_point == pytest.approx(new_point, abs=1e-6)
+    assert orig_vect == pytest.approx(new_vect, abs=1e-6)

--- a/wofs/terrain.py
+++ b/wofs/terrain.py
@@ -44,6 +44,7 @@ def vector_to_crs(point, vector, original_crs, destination_crs):
     Returns a pair of 2-tuples (transformed point and vector).
     Order of coordinates is specified by the CRS (or the OGR library).
     """
+    # pylint: disable=zip-builtin-not-iterating
     # theoretically should use infinitesimal displacement
     # i.e. jacobian of the transformation
     # but here just use a finite displatement (for convenience of implementation)

--- a/wofs/vp_wofs.py
+++ b/wofs/vp_wofs.py
@@ -19,7 +19,7 @@ import wofs.classifier
 # import wofs.terrain
 from wofs.constants import NO_DATA, MASKED_CLOUD, MASKED_CLOUD_SHADOW
 from wofs.filters import eo_filter, terrain_filter
-from datacube.storage import masking
+from datacube.utils import masking
 
 
 def fmask_filter(fmask):

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -488,7 +488,7 @@ def ensure_products(index, app_config, dry_run):
 
 
 @cli.command(help='Generate Tasks into a queue file for later processing')
-@click.option('--app-config', help='Fractional Cover configuration file',
+@click.option('--app-config', help='WOfS configuration file',
               required=True,
               type=click.Path(exists=True, readable=True, writable=False, dir_okay=False))
 @click.option('--output-filename',


### PR DESCRIPTION
In ODC 1.8, CRS objects are no longer OSR objects under the hood, which
caused the terrain shadow calculations to fail.

Convert the code to use ODC geometry operations directly, and implement
a test for the vector transform function.

Also fix a minor warning and typo in some help text.
