### PR TITLE
Feat/mpi and debugability

### DIFF
--- a/tests/use_vp_wofs.py
+++ b/tests/use_vp_wofs.py
@@ -4,7 +4,6 @@ import datacube
 
 import yaml
 
-# from fc.fractional_cover import fractional_cover
 from wofs.vp_wofs import woffles_ard_no_terrain_filter
 
 

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -11,6 +11,7 @@ The three entry points are:
 import copy
 import logging
 import os
+import pickle
 import signal
 import sys
 from collections import defaultdict
@@ -538,6 +539,26 @@ def generate(index: Index,
         output_filename
     )
     _LOG.info('Found %d tasks', num_tasks_saved)
+
+
+@cli.command(help="Display information about a tasks file")
+@click.argument('task_file')
+def inspect_taskfile(task_file):
+    with open(task_file, 'rb') as fin:
+        config = pickle.load(fin)
+        print('CONFIGURATION')
+        print(config)
+        print('\nFIRST TASK')
+        task1 = pickle.load(fin)
+        print(task1)
+        i = 1
+        while True:
+            try:
+                _ = pickle.load(fin)
+                i += 1
+            except EOFError:
+                break
+        print(f'{i} tasks in total')
 
 
 @cli.command(help='Check for existing outputs')

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -635,7 +635,7 @@ def run(index,
     sys.exit(0)
 
 
-@cli.command(name='mpi-convert', help='Bulk COG conversion using MPI')
+@cli.command(name='run-mpi', help='Run using MPI')
 @click.option('--skip-indexing', is_flag=True, default=False,
               help="Generate output files but don't record to database")
 @click.option('--input-filename', required=True,

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -11,6 +11,8 @@ The three entry points are:
 import copy
 import logging
 import os
+import signal
+import sys
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -435,6 +437,14 @@ def _skip_indexing_and_only_log(results):
         _LOG.info('Dataset %s created at %s but not indexed', dataset.id, dataset.uris)
 
 
+def handle_sigterm(signum, frame):
+    # TODO: I expect SIGTERM will be received shortly before PBS SIGKILL's the job.
+    # We could use this to print out the current progress of the job if it's incomplete
+    # Or perhaps even make it resumable.
+    pid = os.getpid()
+    _LOG.error(f'WOfS App PID: {pid}. Received SIGTERM')
+
+
 @click.group(help='Datacube WOfS')
 @click.version_option(version=__version__)
 def cli():
@@ -447,7 +457,7 @@ def cli():
          5) run
     :return: None
     """
-    pass
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
 
 @cli.command(name='list', help='List installed WOfS config files')

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -671,7 +671,7 @@ def mpi_run(index,
     Before using this command, execute the following:
       $ module use /g/data/v10/public/modules/modulefiles/
       $ module load dea
-      $ module load openmpi/3.1.2
+      $ module load openmpi
 
     """
     config, tasks = task_app.load_tasks(input_filename)

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -555,7 +555,7 @@ def run(index,
 
     # TODO: Get rid of this completely
     task_desc = TaskDescription(
-        type_='fc',
+        type_='wofs',
         task_dt=datetime.utcnow().astimezone(timezone.utc),
         events_path=work_dir,
         logs_path=work_dir,

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -679,8 +679,6 @@ def mpi_run(index,
     if redirect_outputs is not None:
         tasks = _prepend_path_to_tasks(redirect_outputs, tasks)
 
-    _LOG.info('Successfully loaded configuration file', config=config)
-
     _LOG.info('Starting WOfS processing...')
     if skip_indexing:
         process_func = _skip_indexing_and_only_log

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -567,7 +567,6 @@ def inspect_taskfile(task_file):
               type=click.Path(exists=True, readable=True, writable=False, dir_okay=False))
 def check_existing(input_filename: str):
     config, tasks = task_app.load_tasks(input_filename)
-    work_dir = Path(input_filename).parent
 
     _LOG.info('Checking for existing output files.')
     # tile_index is X, Y, T
@@ -575,8 +574,17 @@ def check_existing(input_filename: str):
 
 
 def _prepend_path_to_tasks(prepath, tasks):
+    """
+    Prepend prepath to each task's file_path
+
+    Taking special care when prepending to absolute paths.
+    """
     for task in tasks:
-        task['file_path'] = Path(prepath) / task['file_path']
+        file_path = task['file_path']
+        if file_path.is_absolute():
+            task['file_path'] = Path(prepath).joinpath(*file_path.parts[1:])
+        else:
+            task['file_path'] = Path(prepath) / file_path
         yield task
 
 

--- a/wofs/wofs_app.py
+++ b/wofs/wofs_app.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 Entry point for producing WOfS products.
 
@@ -21,12 +20,10 @@ from time import time as time_now
 from typing import Tuple
 
 import click
-import numpy as np
-import xarray
-from pandas import to_datetime
-
 import datacube
 import datacube.model.utils
+import numpy as np
+import xarray
 from datacube.api.grid_workflow import Tile
 from datacube.drivers.netcdf import write_dataset_to_netcdf
 from datacube.index import Index, MissingRecordError
@@ -37,6 +34,7 @@ from datacube.utils.geometry import unary_union, unary_intersection, CRS
 from digitalearthau import paths
 from digitalearthau.qsub import with_qsub_runner, TaskRunner
 from digitalearthau.runners.model import TaskDescription
+from pandas import to_datetime
 from wofs import wofls, __version__
 
 APP_NAME = 'wofs'
@@ -332,7 +330,7 @@ def _do_wofs_task(config, task):
     """
     Load data, run WOFS algorithm, attach metadata, and write output.
     :param dict config: Config object
-    :param dict task: Dictionary of tasks
+    :param dict task: Dictionary of task values
 
     :return: Dataset objects representing the generated data that can be added to the index
     :rtype: list(datacube.model.Dataset)


### PR DESCRIPTION
# Multiple fixes for debuggability and parallelisation

- Add ability to run in parallel using MPI
- Allow redirecting output files to a different directly, for safely re-running for testing
- Add a new command to check for existing files from a `tasks.pickle`
- Add a new command for inspecting a `tasks.pickle` file.