### PR TITLE
Replace deprecated numpy data types

### DIFF
--- a/wofs-summary/simple.py
+++ b/wofs-summary/simple.py
@@ -91,8 +91,8 @@ class fuser:
         for tile in self.tiles[1:]:
             # TODO: could numexpr
             subsequent = tile.water
-            empty = (output & 1).astype(np.bool)
-            both = ~empty & ~((subsequent & 1).astype(np.bool))
+            empty = (output & 1).astype(bool)
+            both = ~empty & ~((subsequent & 1).astype(bool))
             output[empty] = subsequent[empty]
             output[both] |= subsequent[both]
         return output

--- a/wofs/filters.py
+++ b/wofs/filters.py
@@ -51,9 +51,9 @@ def pq_filter(pq):
 
     masking = np.zeros(ipq.shape, dtype=np.uint8)
     masking[
-        (ipq & (PQA_SATURATION_BITS | PQA_CONTIGUITY_BITS)).astype(np.bool)
+        (ipq & (PQA_SATURATION_BITS | PQA_CONTIGUITY_BITS)).astype(bool)
     ] = constants.MASKED_NO_CONTIGUITY
-    # masking[(ipq & PQA_SEA_WATER_BIT).astype(np.bool)] += constants.MASKED_SEA_WATER
+    # masking[(ipq & PQA_SEA_WATER_BIT).astype(bool)] += constants.MASKED_SEA_WATER
     masking[dilate(ipq & PQA_CLOUD_BITS)] += constants.MASKED_CLOUD
     masking[dilate(ipq & PQA_CLOUD_SHADOW_BITS)] += constants.MASKED_CLOUD_SHADOW
     return masking
@@ -94,9 +94,9 @@ def c2_filter(pq):
 
     masking = np.zeros(pq.shape, dtype=np.uint8)
     masking[
-        ((pq & C2_DILATED_BITS)).astype(np.bool)
-        | ((pq & C2_CLOUD_BITS)).astype(np.bool)
-        | ((pq & C2_CIRRUS_BITS)).astype(np.bool)
+        ((pq & C2_DILATED_BITS)).astype(bool)
+        | ((pq & C2_CLOUD_BITS)).astype(bool)
+        | ((pq & C2_CIRRUS_BITS)).astype(bool)
     ] += constants.MASKED_CLOUD
     masking[dilate(pq & C2_CLOUD_SHADOW_BITS)] += constants.MASKED_CLOUD_SHADOW
     return masking


### PR DESCRIPTION
Currently wofs is restricted to numpy<=1.24.1 to avoid np.bool deprecation. This patch allows wofs to be used with numpy>1.24.1

Ref: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Tested with custom builds and pytest (relevant tests passed) but I don't have a full test suite particularly for any operational considerations. Nevertheless this update should be back- and forward-compatible.

